### PR TITLE
Accessibility improvements

### DIFF
--- a/src/_includes/footer.liquid
+++ b/src/_includes/footer.liquid
@@ -11,7 +11,7 @@
 
   <ul>
     <li>
-      <a href="#">
+      <a href="#top">
         <img src="https://s3.amazonaws.com/palomakop.tv/icons/up_arrow.svg" alt=""/> <span>Top of page</span>
       </a>
     </li>

--- a/src/_includes/global.liquid
+++ b/src/_includes/global.liquid
@@ -14,7 +14,7 @@ containerType: column
 ---
 {% include "head.liquid" %}
 
-<body>
+<body id="top">
 
   {% if bgImage %}
   <div class="bg"></div>

--- a/src/_includes/menu.liquid
+++ b/src/_includes/menu.liquid
@@ -2,6 +2,7 @@
   <mobile-nav>
     <a href="##" class="mobile-nav-icon close-button">
       <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+        <title>Close menu</title>
         <g id="x-icon" transform="translate(0, 0)">
           <rect x="15" y="45" width="70" height="10" rx="3" ry="3" fill="currentColor" 
                 transform="rotate(45, 50, 50)" />

--- a/src/_includes/navLinks.liquid
+++ b/src/_includes/navLinks.liquid
@@ -1,17 +1,17 @@
 <ul>
   <li>
-    <a href="/" class="{% if page.url == "/" %}current-link{% endif %}">about</a>
+    <a href="/" {% if page.url == "/" %}class="current-link" aria-current="page"{% endif %}>about</a>
   </li>
   <li>
-    <a href="/code" class="{% if page.url == "/code/" %}current-link{% endif %}">code</a>
+    <a href="/code" {% if page.url == "/code/" %}class="current-link" aria-current="page"{% endif %}>code</a>
   </li>
   <li>
-    <a href="/art" class="{% if page.url == "/art/" %}current-link{% endif %}">art</a>
+    <a href="/art" {% if page.url == "/art/" %}class="current-link" aria-current="page"{% endif %}>art</a>
   </li>
   <li>
-    <a href="/blog" class="{% if page.url == "/blog/" %}current-link{% endif %}">blog</a>
+    <a href="/blog" {% if page.url == "/blog/" %}class="current-link" aria-current="page"{% endif %}>blog</a>
   </li>
   <li>
-    <a href="/contact" class="{% if page.url == "/contact/" %}current-link{% endif %}">contact</a>
+    <a href="/contact" {% if page.url == "/contact/" %}class="current-link" aria-current="page"{% endif %}>contact</a>
   </li>
 </ul>

--- a/src/_includes/sidebar.liquid
+++ b/src/_includes/sidebar.liquid
@@ -1,6 +1,6 @@
 <header>
   <mobile-header>
-    <h1><a href="/" class="{% if page.url == "/" %}current-link{% endif %}"><img src="https://s3.amazonaws.com/palomakop.tv/header.svg" class="header-image" alt="Paloma Kop"/></a></h1>
+    <h1><a href="/" {% if page.url == "/" %}class="current-link" aria-current="page"{% endif %}><img src="https://s3.amazonaws.com/palomakop.tv/header.svg" class="header-image" alt="Paloma Kop"/></a></h1>
     <a href="#menu" class="mobile-nav-icon">
       <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
         <title>Navigation menu</title>
@@ -13,7 +13,7 @@
     </a>
   </mobile-header>
   <desktop-sidebar>
-    <h1><a href="/" class="{% if page.url == "/" %}current-link{% endif %}"><img src="https://s3.amazonaws.com/palomakop.tv/header_sidebar.svg" class="header-image" alt="Paloma Kop"/></a></h1>
+    <h1><a href="/" {% if page.url == "/" %}class="current-link" aria-current="page"{% endif %}><img src="https://s3.amazonaws.com/palomakop.tv/header_sidebar.svg" class="header-image" alt="Paloma Kop"/></a></h1>
     <sidebar-nav>
       {% include "navLinks.liquid" %}
     </sidebar-nav>

--- a/src/_includes/sidebar.liquid
+++ b/src/_includes/sidebar.liquid
@@ -3,6 +3,7 @@
     <h1><a href="/" class="{% if page.url == "/" %}current-link{% endif %}"><img src="https://s3.amazonaws.com/palomakop.tv/header.svg" class="header-image" alt="Paloma Kop"/></a></h1>
     <a href="#menu" class="mobile-nav-icon">
       <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+        <title>Navigation menu</title>
         <g id="hamburger" transform="translate(0, 0)">
           <rect x="15" y="25" width="70" height="10" rx="3" ry="3" fill="currentColor" />
           <rect x="15" y="45" width="70" height="10" rx="3" ry="3" fill="currentColor" />

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1414,10 +1414,6 @@ form button {
   margin:0.5em 0 2em;
 }
 
-:focus-visible {
-  outline:none;
-}
-
 /* ZINE CLUB TIERS */
 
 .tier-gallery {

--- a/src/index.liquid
+++ b/src/index.liquid
@@ -42,7 +42,7 @@ customStyle: >
           <a href="/blog">blog</a>
         </li>
         <li class="mobile-only">
-          <a class="icon-link" href="/contact"><img src="https://s3.amazonaws.com/palomakop.tv/icons/contact_lighter.svg"></a>
+          <a class="icon-link" href="/contact"><img src="https://s3.amazonaws.com/palomakop.tv/icons/contact_lighter.svg" alt="contact" width="300" height="300"></a>
         </li>
         <li class="desktop-only">
           <a href="/contact">Contact</a>


### PR DESCRIPTION
The commit messages contain more details, but broadly, this PR makes the following changes in the name of improving accessibility and overall user experience:

- Added `width`, `height`, and `alt` attributes to `<img>` elements used as icon links to [reduce layout shifts during loading](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/img#height) and [improve the experience for users of accessibility tools](https://www.w3.org/WAI/WCAG22/Understanding/non-text-content.html) like screen readers.
- Similarly, added [`<title>`](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/title) elements to `<svg>`s that have no text alternative used as links.
- Added the [`aria-current` attribute](https://w3c.github.io/aria/#aria-current) to links that represent the current page.
- Added a `#top` anchor to the `<body>` element for the "Top of page" link to target, which moves both the scroll position _and_ keyboard focus back to the top of the page.
- Re-enabled the [focus outline](https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible#accessibility) (removed in eb8d89bc571f6f77f2934f8ecf407e38b097cdf9) to allow links to be navigated by keyboard visually.